### PR TITLE
restore shell access after closing our application

### DIFF
--- a/dbv/cli.py
+++ b/dbv/cli.py
@@ -36,18 +36,24 @@ def main(filename: str) -> None:
 
     TODO add more info to this help message
     """
-    # Puts the terminal into cbreak mode, meaning keys aren't echoed to the screen
-    # and can be read immediately without input buffering.
-    tty.setcbreak(sys.stdin.fileno())
+    # stores terminal attributes to restore after closing the application
+    stdin = sys.stdin.fileno()
+    tattr = tty.tcgetattr(stdin)
 
-    df = load_df(filename)
-    interface = Interface(df, filename)
+    try:
+        # Puts the terminal into cbreak mode, meaning keys aren't echoed to the screen
+        # and can be read immediately without input buffering.
+        tty.setcbreak(sys.stdin.fileno())
 
-    with Live(interface, screen=True) as live:
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(
-            consume_keyboard_events(interface.keyboard_handler, live)
-        )
+        df = load_df(filename)
+        interface = Interface(df, filename)
+
+        with Live(interface, screen=True) as live:
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(consume_keyboard_events(interface.keyboard_handler, live))
+
+    finally:  # restores the terminal to default behavior
+        tty.tcsetattr(stdin, tty.TCSANOW, tattr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Restores the stdin capability after running/exiting our TUI application.  I saved the stdin into a variable at the start of the main function, wrapped the existing code in a "try" block, and added a "finally" that restores the terminal shell.


After running and closing the terminal, both my WSL2 computer and my Linux computer were "hiding" text typed into the terminal.  Bunny reported not seeing the issue in OSX - I'd like to see that I didn't inadvertently break anything in that OS.


Code "inspired" by digging through curses and https://stackoverflow.com/questions/37726138/disable-buffering-of-sys-stdin-in-python-3
